### PR TITLE
Removed String.join as it is not supported in API Levels below 26

### DIFF
--- a/client/src/main/java/com/fiskaly/kassensichv/client/interceptors/TransactionInterceptor.java
+++ b/client/src/main/java/com/fiskaly/kassensichv/client/interceptors/TransactionInterceptor.java
@@ -60,8 +60,7 @@ public class TransactionInterceptor implements Interceptor {
         String queryList = "";
 
         if(!parts.isEmpty()){
-            queryList += parts.get(0);
-            parts.remove(0);
+            queryList += parts.remove(0);
 
             for (String part : parts) {
                 queryList += ("?" + part);

--- a/client/src/main/java/com/fiskaly/kassensichv/client/interceptors/TransactionInterceptor.java
+++ b/client/src/main/java/com/fiskaly/kassensichv/client/interceptors/TransactionInterceptor.java
@@ -56,7 +56,17 @@ public class TransactionInterceptor implements Interceptor {
         List<String> parts = new LinkedList<>(Arrays.asList(sourceUrl.split("\\?")));
 
         String host = parts.remove(0);
-        String queryList = String.join("?", parts);
+
+        String queryList = "";
+
+        if(!parts.isEmpty()){
+            queryList += parts.get(0);
+            parts.remove(0);
+
+            for (String part : parts) {
+                queryList += ("?" + part);
+            }
+        }
 
         if (!queryList.isEmpty()) {
             queryList = "?" + queryList;


### PR DESCRIPTION
The functionality of the String.join is now coded in plain Java and should be supported by all API Levels of Android.
Done because of #25 