### PR TITLE
Fix automatic retries when authentication fails

### DIFF
--- a/client/src/main/java/com/fiskaly/kassensichv/client/authentication/Authenticator.java
+++ b/client/src/main/java/com/fiskaly/kassensichv/client/authentication/Authenticator.java
@@ -4,6 +4,8 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Route;
 
+import java.io.IOException;
+
 /**
  * Runs token refreshment logic in case a 401 response occurs
  */
@@ -15,11 +17,11 @@ public class Authenticator implements okhttp3.Authenticator {
     }
 
     @Override
-    public synchronized Request authenticate(Route route, Response response) {
-
+    public synchronized Request authenticate(Route route, Response response) throws IOException {
         // Give up, we've already failed to authenticate in the last try
-        if (response.request().header("Authorization") != null) {
-            return null;
+        if (response.request().header("Authorization") != null &&
+                response.request().header("X-Authorization-Retry") != null) {
+            throw new IOException("Bad Credentials. Authorization Failed.");
         }
 
         // Force refresh
@@ -27,6 +29,7 @@ public class Authenticator implements okhttp3.Authenticator {
 
         return response.request().newBuilder()
                 .header("Authorization", "Bearer" + tokenManager.getAccessToken())
+                .header("X-Authorization-Retry", "1")
                 .build();
     }
 }

--- a/client/src/main/java/com/fiskaly/kassensichv/client/authentication/Authenticator.java
+++ b/client/src/main/java/com/fiskaly/kassensichv/client/authentication/Authenticator.java
@@ -28,7 +28,7 @@ public class Authenticator implements okhttp3.Authenticator {
         tokenManager.fetchTokenPair();
 
         return response.request().newBuilder()
-                .header("Authorization", "Bearer" + tokenManager.getAccessToken())
+                .header("Authorization", "Bearer " + tokenManager.getAccessToken())
                 .header("X-Authorization-Retry", "1")
                 .build();
     }

--- a/client/src/main/java/com/fiskaly/kassensichv/client/authentication/Authenticator.java
+++ b/client/src/main/java/com/fiskaly/kassensichv/client/authentication/Authenticator.java
@@ -16,6 +16,12 @@ public class Authenticator implements okhttp3.Authenticator {
 
     @Override
     public synchronized Request authenticate(Route route, Response response) {
+
+        // Give up, we've already failed to authenticate in the last try
+        if (response.request().header("Authorization") != null) {
+            return null;
+        }
+
         // Force refresh
         tokenManager.fetchTokenPair();
 

--- a/client/src/main/java/com/fiskaly/kassensichv/client/authentication/TokenManager.java
+++ b/client/src/main/java/com/fiskaly/kassensichv/client/authentication/TokenManager.java
@@ -72,7 +72,6 @@ public class TokenManager implements Runnable {
 
         // First fetch
         if (this.tokenHolder.accessToken == null) {
-            System.out.println("first fetch");
             String jsonBody =
                 "{" +
                     "\"api_key\":\"" + this.apiKey + "\"," +

--- a/client/src/main/java/com/fiskaly/kassensichv/client/authentication/TokenManager.java
+++ b/client/src/main/java/com/fiskaly/kassensichv/client/authentication/TokenManager.java
@@ -88,11 +88,19 @@ public class TokenManager implements Runnable {
                 .build();
 
         try(Response response = client.newCall(request).execute()) {
-            this.setTokenPairFromResponseBody(
-                response
-                    .body()
-                    .string()
-            );
+            if(response.isSuccessful()) {
+                this.setTokenPairFromResponseBody(
+                    response
+                        .body()
+                        .string()
+                );
+            } else if(this.accessToken != null){
+                System.err.println("refresh_token Auth failed, falling back to API Pair Auth.");
+                this.accessToken = null;
+                this.fetchTokenPair();
+            } else {
+                System.err.println("Bad Credentials.");
+            }
         } catch (IOException ioe) {
             System.err.println(ioe);
         }

--- a/client/src/main/java/com/fiskaly/kassensichv/client/authentication/TokenManager.java
+++ b/client/src/main/java/com/fiskaly/kassensichv/client/authentication/TokenManager.java
@@ -95,7 +95,7 @@ public class TokenManager implements Runnable {
                         .string()
                 );
             } else if(this.accessToken != null){
-                System.err.println("refresh_token Auth failed, falling back to API Pair Auth.");
+                System.err.println("refresh_token seems to be incorrect or expired. Falling back to authorization with API-Key and API-Secret.");
                 this.accessToken = null;
                 this.fetchTokenPair();
             } else {

--- a/client/src/test/java/AuthenticationRetryRequestTest.java
+++ b/client/src/test/java/AuthenticationRetryRequestTest.java
@@ -1,0 +1,309 @@
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fiskaly.kassensichv.client.interceptors.HeaderInterceptor;
+import com.fiskaly.kassensichv.client.interceptors.TransactionInterceptor;
+import com.fiskaly.kassensichv.sma.SmaInterface;
+import okhttp3.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class AuthenticationRetryRequestTest {
+
+    private static final String apiKey = System.getenv("API_KEY");
+    private static final String apiSecret = System.getenv("API_SECRET");
+
+    private static TestTokenManager tokenManager;
+
+    private static OkHttpClient getClient(String apiKey, String secret, SmaInterface sma) {
+        tokenManager = new TestTokenManager(
+                new OkHttpClient
+                        .Builder()
+                        .build(),
+                apiKey,
+                secret);
+
+        OkHttpClient client = new OkHttpClient
+                .Builder()
+                .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
+                .addInterceptor(new HeaderInterceptor())
+                .addInterceptor(new TestAuthenticationInterceptor(tokenManager))
+                .addInterceptor(new TransactionInterceptor(sma))
+                .authenticator(new TestAuthenticator(tokenManager))
+                .build();
+
+        return client;
+    }
+
+    @Test(expected = IOException.class)
+    public void AR01_GivenNoApiPairWhenSendingRequestExpectException() throws Exception {
+
+        OkHttpClient client = getClient(null, null, SmaProvider.getSma());
+
+        final String BASE_URL = "https://kassensichv.io/api/v0/";
+        final Request request = new Request.Builder()
+                .url(BASE_URL + "client")
+                .get()
+                .build();
+        final Response response = client
+                .newCall(request)
+                .execute();
+
+    }
+
+    @Test(expected = IOException.class)
+    public void AR02_GivenWrongApiPairWhenSendingRequestExpectException() throws Exception {
+
+        OkHttpClient client = getClient("IAMAKEY", "IAMASECRET", SmaProvider.getSma());
+
+        final String BASE_URL = "https://kassensichv.io/api/v0/";
+        final Request request = new Request.Builder()
+                .url(BASE_URL + "client")
+                .get()
+                .build();
+        final Response response = client
+                .newCall(request)
+                .execute();
+
+    }
+
+    @Test
+    public void AR03_GivenCorrectApiPairWhenSendingRequestExpectSuccess() throws Exception {
+
+        OkHttpClient client = getClient(apiKey, apiSecret, SmaProvider.getSma());
+
+        final String BASE_URL = "https://kassensichv.io/api/v0/";
+        final Request request = new Request.Builder()
+                .url(BASE_URL + "client")
+                .get()
+                .build();
+        final Response response = client
+                .newCall(request)
+                .execute();
+
+    }
+
+    @Test
+    public void AR04_GivenCorrectApiPairWhenInvalidAccessTokenAndSendingRequestExpectSuccess() throws Exception {
+
+        OkHttpClient client = getClient(apiKey, apiSecret, SmaProvider.getSma());
+
+        final String BASE_URL = "https://kassensichv.io/api/v0/";
+        final Request request = new Request.Builder()
+                .url(BASE_URL + "client")
+                .get()
+                .build();
+        final Response response = client
+                .newCall(request)
+                .execute();
+
+        tokenManager.setAccessToken("invalidToken");
+
+        final Response response2 = client
+                .newCall(request)
+                .execute();
+
+    }
+
+    @Test
+    public void AR05_GivenCorrectApiPairWhenInvalidAccessTokenAndInvalidRefreshTokenAndSendingRequestExpectSuccess() throws Exception {
+
+        OkHttpClient client = getClient(apiKey, apiSecret, SmaProvider.getSma());
+
+        final String BASE_URL = "https://kassensichv.io/api/v0/";
+        final Request request = new Request.Builder()
+                .url(BASE_URL + "client")
+                .get()
+                .build();
+        final Response response = client
+                .newCall(request)
+                .execute();
+
+        tokenManager.setAccessToken("invalidToken");
+        tokenManager.setRefreshToken("invalidToken");
+
+        final Response response2 = client
+                .newCall(request)
+                .execute();
+    }
+
+}
+
+class TestTokenManager implements Runnable {
+    private OkHttpClient client;
+
+    private final String apiKey;
+    private final String secret;
+
+    private String accessToken;
+    private String refreshToken;
+
+    private final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public TestTokenManager(OkHttpClient client, String apiKey, String secret) {
+        this.client = client;
+
+        this.apiKey = apiKey;
+        this.secret = secret;
+    }
+
+    private synchronized void setTokenPair(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public synchronized String getAccessToken() {
+        return this.accessToken;
+    }
+
+    /**
+     * Parses the response of the authentication request
+     * and extracts the token pair
+     * @param responseBody Response body of the authentication request
+     * @throws IOException In case of the body not being parsable
+     */
+    private synchronized void setTokenPairFromResponseBody(String responseBody) throws IOException {
+        final TypeReference<HashMap<String, String>> typeReference =
+                new TypeReference<>() {};
+
+        Map<String, String> decodedBody = mapper.readValue(responseBody, typeReference);
+
+        String accessToken = decodedBody.get("access_token");
+        String refreshToken = decodedBody.get("refresh_token");
+
+        this.setTokenPair(accessToken, refreshToken);
+    }
+
+    public synchronized void fetchTokenPair() {
+        Request request;
+        RequestBody body;
+
+        // First fetch
+        if (this.accessToken == null) {
+            String jsonBody =
+                    "{" +
+                            "\"api_key\":\"" + this.apiKey + "\"," +
+                            "\"api_secret\": \"" + this.secret + "\"" +
+                            "}";
+            body = RequestBody.create(jsonBody, JSON);
+            // Token needs to be refreshed
+        } else {
+            String jsonBody =
+                    "{" +
+                            "\"refresh_token\": \"" + this.refreshToken + "\"" +
+                            "}";
+            body = RequestBody.create(jsonBody, JSON);
+        }
+
+        request = new Request
+                .Builder()
+                .url("https://kassensichv.io/api/v0/auth")
+                .post(body)
+                .build();
+        try(Response response = this.client.newCall(request).execute()) {
+            if(response.isSuccessful()) {
+                this.setTokenPairFromResponseBody(
+                        response
+                                .body()
+                                .string()
+                );
+            } else if(this.accessToken != null){
+                System.err.println("refresh_token seems to be incorrect or expired. Falling back to authorization with API-Key and API-Secret.");
+                this.accessToken = null;
+                this.fetchTokenPair();
+            } else {
+                System.err.println("Bad Credentials.");
+            }
+        } catch (IOException ioe) {
+            System.err.println(ioe);
+        }
+
+
+    }
+
+    public synchronized void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public synchronized void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    // Gets called when token needs to be refreshed
+    @Override
+    public void run() {
+        fetchTokenPair();
+    }
+}
+
+class TestAuthenticationInterceptor implements Interceptor {
+    private final ScheduledExecutorService executor;
+    private final TestTokenManager tokenManager;
+
+    public TestAuthenticationInterceptor(final TestTokenManager tokenManager) {
+        this.tokenManager = tokenManager;
+        this.executor = Executors.newScheduledThreadPool(1);
+
+        this.startTokenManagementTask();
+    }
+
+    /**
+     * Starts an async task that is responsible
+     * for keeping the access token-pair active
+     */
+    private void startTokenManagementTask() {
+        final int INITIAL_DELAY = 0;
+        final int REFRESH_INTERVAL = 30;
+
+        this.executor
+                .scheduleWithFixedDelay(
+                        this.tokenManager,
+                        INITIAL_DELAY,
+                        REFRESH_INTERVAL,
+                        TimeUnit.SECONDS
+                );
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        Request interceptedRequest = request
+                .newBuilder()
+                .header("Authorization", "Bearer " + this.tokenManager.getAccessToken())
+                .build();
+
+        return chain.proceed(interceptedRequest);
+    }
+}
+
+class TestAuthenticator implements okhttp3.Authenticator {
+    private TestTokenManager tokenManager;
+
+    public TestAuthenticator(TestTokenManager tokenManager) {
+        this.tokenManager = tokenManager;
+    }
+
+    @Override
+    public synchronized Request authenticate(Route route, Response response) throws IOException {
+        // Give up, we've already failed to authenticate in the last try
+        if (response.request().header("Authorization") != null &&
+                response.request().header("X-Authorization-Retry") != null) {
+            throw new IOException("Bad Credentials. Authorization Failed.");
+        }
+
+        // Force refresh
+        this.tokenManager.fetchTokenPair();
+
+        return response.request().newBuilder()
+                .header("Authorization", "Bearer " + this.tokenManager.getAccessToken())
+                .header("X-Authorization-Retry", "1")
+                .build();
+    }
+}

--- a/client/src/test/java/AuthenticationRetryRequestTest.java
+++ b/client/src/test/java/AuthenticationRetryRequestTest.java
@@ -1,44 +1,48 @@
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fiskaly.kassensichv.client.authentication.TokenManager;
+import com.fiskaly.kassensichv.client.authentication.Authenticator;
+import com.fiskaly.kassensichv.client.interceptors.AuthenticationInterceptor;
 import com.fiskaly.kassensichv.client.interceptors.HeaderInterceptor;
 import com.fiskaly.kassensichv.client.interceptors.TransactionInterceptor;
 import com.fiskaly.kassensichv.sma.SmaInterface;
 import okhttp3.*;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 public class AuthenticationRetryRequestTest {
 
     private static final String apiKey = System.getenv("API_KEY");
     private static final String apiSecret = System.getenv("API_SECRET");
 
-    private static TestTokenManager tokenManager;
+    private static TokenManager.TokenHolder tokenHolder;
+    private static TokenManager tokenManager;
 
     private static OkHttpClient getClient(String apiKey, String secret, SmaInterface sma) {
-        tokenManager = new TestTokenManager(
+        tokenManager = new TokenManager(
                 new OkHttpClient
                         .Builder()
                         .build(),
                 apiKey,
-                secret);
+                secret,
+                tokenHolder);
 
         OkHttpClient client = new OkHttpClient
                 .Builder()
                 .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
                 .addInterceptor(new HeaderInterceptor())
-                .addInterceptor(new TestAuthenticationInterceptor(tokenManager))
+                .addInterceptor(new AuthenticationInterceptor(tokenManager))
                 .addInterceptor(new TransactionInterceptor(sma))
-                .authenticator(new TestAuthenticator(tokenManager))
+                .authenticator(new Authenticator(tokenManager))
                 .build();
 
         return client;
+    }
+
+    @Before
+    public void resetTokenHolder() {
+        tokenHolder = new TokenManager.TokenHolder();
     }
 
     @Test(expected = IOException.class)
@@ -51,9 +55,7 @@ public class AuthenticationRetryRequestTest {
                 .url(BASE_URL + "client")
                 .get()
                 .build();
-        final Response response = client
-                .newCall(request)
-                .execute();
+        client.newCall(request).execute();
 
     }
 
@@ -67,9 +69,7 @@ public class AuthenticationRetryRequestTest {
                 .url(BASE_URL + "client")
                 .get()
                 .build();
-        final Response response = client
-                .newCall(request)
-                .execute();
+        client.newCall(request).execute();
 
     }
 
@@ -83,9 +83,7 @@ public class AuthenticationRetryRequestTest {
                 .url(BASE_URL + "client")
                 .get()
                 .build();
-        final Response response = client
-                .newCall(request)
-                .execute();
+        client.newCall(request).execute();
 
     }
 
@@ -103,11 +101,9 @@ public class AuthenticationRetryRequestTest {
                 .newCall(request)
                 .execute();
 
-        tokenManager.setAccessToken("invalidToken");
+        tokenHolder.accessToken = "invalidToken";
 
-        final Response response2 = client
-                .newCall(request)
-                .execute();
+        client.newCall(request).execute();
 
     }
 
@@ -125,185 +121,10 @@ public class AuthenticationRetryRequestTest {
                 .newCall(request)
                 .execute();
 
-        tokenManager.setAccessToken("invalidToken");
-        tokenManager.setRefreshToken("invalidToken");
+        tokenHolder.accessToken = "invalidToken";
+        tokenHolder.refreshToken = "invalidToken";
 
-        final Response response2 = client
-                .newCall(request)
-                .execute();
+        client.newCall(request).execute();
     }
 
-}
-
-class TestTokenManager implements Runnable {
-    private OkHttpClient client;
-
-    private final String apiKey;
-    private final String secret;
-
-    private String accessToken;
-    private String refreshToken;
-
-    private final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-    private final ObjectMapper mapper = new ObjectMapper();
-
-    public TestTokenManager(OkHttpClient client, String apiKey, String secret) {
-        this.client = client;
-
-        this.apiKey = apiKey;
-        this.secret = secret;
-    }
-
-    private synchronized void setTokenPair(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }
-
-    public synchronized String getAccessToken() {
-        return this.accessToken;
-    }
-
-    /**
-     * Parses the response of the authentication request
-     * and extracts the token pair
-     * @param responseBody Response body of the authentication request
-     * @throws IOException In case of the body not being parsable
-     */
-    private synchronized void setTokenPairFromResponseBody(String responseBody) throws IOException {
-        final TypeReference<HashMap<String, String>> typeReference =
-                new TypeReference<>() {};
-
-        Map<String, String> decodedBody = mapper.readValue(responseBody, typeReference);
-
-        String accessToken = decodedBody.get("access_token");
-        String refreshToken = decodedBody.get("refresh_token");
-
-        this.setTokenPair(accessToken, refreshToken);
-    }
-
-    public synchronized void fetchTokenPair() {
-        Request request;
-        RequestBody body;
-
-        // First fetch
-        if (this.accessToken == null) {
-            String jsonBody =
-                    "{" +
-                            "\"api_key\":\"" + this.apiKey + "\"," +
-                            "\"api_secret\": \"" + this.secret + "\"" +
-                            "}";
-            body = RequestBody.create(jsonBody, JSON);
-            // Token needs to be refreshed
-        } else {
-            String jsonBody =
-                    "{" +
-                            "\"refresh_token\": \"" + this.refreshToken + "\"" +
-                            "}";
-            body = RequestBody.create(jsonBody, JSON);
-        }
-
-        request = new Request
-                .Builder()
-                .url("https://kassensichv.io/api/v0/auth")
-                .post(body)
-                .build();
-        try(Response response = this.client.newCall(request).execute()) {
-            if(response.isSuccessful()) {
-                this.setTokenPairFromResponseBody(
-                        response
-                                .body()
-                                .string()
-                );
-            } else if(this.accessToken != null){
-                System.err.println("refresh_token seems to be incorrect or expired. Falling back to authorization with API-Key and API-Secret.");
-                this.accessToken = null;
-                this.fetchTokenPair();
-            } else {
-                System.err.println("Bad Credentials.");
-            }
-        } catch (IOException ioe) {
-            System.err.println(ioe);
-        }
-
-
-    }
-
-    public synchronized void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
-
-    public synchronized void setRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
-    // Gets called when token needs to be refreshed
-    @Override
-    public void run() {
-        fetchTokenPair();
-    }
-}
-
-class TestAuthenticationInterceptor implements Interceptor {
-    private final ScheduledExecutorService executor;
-    private final TestTokenManager tokenManager;
-
-    public TestAuthenticationInterceptor(final TestTokenManager tokenManager) {
-        this.tokenManager = tokenManager;
-        this.executor = Executors.newScheduledThreadPool(1);
-
-        this.startTokenManagementTask();
-    }
-
-    /**
-     * Starts an async task that is responsible
-     * for keeping the access token-pair active
-     */
-    private void startTokenManagementTask() {
-        final int INITIAL_DELAY = 0;
-        final int REFRESH_INTERVAL = 30;
-
-        this.executor
-                .scheduleWithFixedDelay(
-                        this.tokenManager,
-                        INITIAL_DELAY,
-                        REFRESH_INTERVAL,
-                        TimeUnit.SECONDS
-                );
-    }
-
-    @Override
-    public Response intercept(Chain chain) throws IOException {
-        Request request = chain.request();
-        Request interceptedRequest = request
-                .newBuilder()
-                .header("Authorization", "Bearer " + this.tokenManager.getAccessToken())
-                .build();
-
-        return chain.proceed(interceptedRequest);
-    }
-}
-
-class TestAuthenticator implements okhttp3.Authenticator {
-    private TestTokenManager tokenManager;
-
-    public TestAuthenticator(TestTokenManager tokenManager) {
-        this.tokenManager = tokenManager;
-    }
-
-    @Override
-    public synchronized Request authenticate(Route route, Response response) throws IOException {
-        // Give up, we've already failed to authenticate in the last try
-        if (response.request().header("Authorization") != null &&
-                response.request().header("X-Authorization-Retry") != null) {
-            throw new IOException("Bad Credentials. Authorization Failed.");
-        }
-
-        // Force refresh
-        this.tokenManager.fetchTokenPair();
-
-        return response.request().newBuilder()
-                .header("Authorization", "Bearer " + this.tokenManager.getAccessToken())
-                .header("X-Authorization-Retry", "1")
-                .build();
-    }
 }


### PR DESCRIPTION
Motivation: Issue #10 

- We know for a fact, that failed Authentication will cause to many follow-up requests
- We think that the random behavior mentioned in the Issue are caused by <s>expired refresh_tokens</s> the missing space character in the Authenticator class

This PR: 

- Adds logic to the tokenManager, that causes it to retry authentication with API-Key and API-Secret if the authentication with the refresh_token fails
- Adds logic to the Authenticator, that causes him to give up, if the last request that came back with a 401 error already had an authorization key
- With 5724599 also adds a Test-Class to prove the changes work as expected

Possible Problems: 

- <s>Authenticator might return null too soon if resfresh_token is expired, need someone to check if this is true</s> This was the case. Changed in f5db52b